### PR TITLE
change previous mentions of `text` to `display`

### DIFF
--- a/barfi/block_builder.py
+++ b/barfi/block_builder.py
@@ -128,7 +128,7 @@ class Block(object):
 
         Interactive options interface:
             name (str)  : The name of the Option interface.
-            type (str)  : The type of the Option interface. 'checkbox', 'input', 'integer', 'number', 'select', 'slider', 'text'.
+            type (str)  : The type of the Option interface. 'checkbox', 'input', 'integer', 'number', 'select', 'slider', 'display'.
             value       : The default value for the option. Depends on the option chosen.
 
             Additional properties depending on the type of Option interface.

--- a/barfi/option_builder.py
+++ b/barfi/option_builder.py
@@ -123,7 +123,7 @@ def build_option(name: str, type: str, kwargs):
         option['type'] = "TextOption"
         value = kwargs.get('value', "null display")
         assert isinstance(
-            value, str), "Error: For text option, 'value' must be of type string."
+            value, str), "Error: For display option, 'value' must be of type string."
         option['value'] = value
 
     else:


### PR DESCRIPTION
When looking through available options (as I do, with `Block.add_options?` in `ipython`), an option `text` was mentioned. However, it wasn't available when I tried using it.

I'm assuming that the option was called `text` at some point prior, and that it has since been renamed to `display`. Thus, I propose changing `text` to `display` in 1) documentation and 2) error messages for consistency.